### PR TITLE
Add Aarc protocol

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,6 +42,7 @@
 
 ## Chain Abstraction Protocols
 
+- [Aarc](https://twitter.com/0xAarc)
 - [Agoric](https://twitter.com/agoric)
 - [Connext](https://twitter.com/Connext)
 - [Near Protocol](https://twitter.com/NEARProtocol)


### PR DESCRIPTION
Hey folks!

I have added Aarc in the protocol section of the docs. Aarc is working towards building a modular protocol unifying fragmented wallets, liquidity, and gas markets across blockchains for a seamless user experience. We already have the fund kit and Open Auth kit live for liquidity and wallet aggregation.